### PR TITLE
refactor(android-sdk): suggestions

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -10,6 +10,7 @@ espressoCore = "3.5.1"
 grpc = "1.58.0"
 grpcKotlin = "1.4.0"
 junitJupiter = "5.10.0"
+kotest = "5.7.2"
 kotlin = "1.9.10"
 kotlinX = "1.7.3"
 ktlintPlugin = "11.6.0"
@@ -34,6 +35,8 @@ grpc-testing = { module = "io.grpc:grpc-testing", version.ref = "grpc" }
 junit-jupiter-api = { module = "org.junit.jupiter:junit-jupiter-api", version.ref = "junitJupiter" }
 junit-jupiter-engine = { module = "org.junit.jupiter:junit-jupiter-engine", version.ref = "junitJupiter" }
 junit-jupiter-params = { module = "org.junit.jupiter:junit-jupiter-params", version.ref = "junitJupiter" }
+kotest-assertions-core = { module = "io.kotest:kotest-assertions-core", version.ref = "kotest"}
+kotest-assertions-android = { module = "io.kotest:kotest-assertions-android", version.ref = "kotest"}
 kotlinx-coroutines-core = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version.ref = "kotlinX" }
 system-stubs-jupiter = { module = "uk.org.webcompere:system-stubs-jupiter", version.ref = "systemStubsJupiter" }
 

--- a/sdks/android/sdk/build.gradle.kts
+++ b/sdks/android/sdk/build.gradle.kts
@@ -53,6 +53,7 @@ dependencies {
     testImplementation(libs.junit.jupiter.api)
     testImplementation(libs.junit.jupiter.params)
     testImplementation(libs.system.stubs.jupiter)
+    testImplementation(libs.kotest.assertions.core)
     testRuntimeOnly(libs.junit.jupiter.engine)
 
     compileOnly(libs.annotations.api)

--- a/sdks/android/sdk/src/main/kotlin/ai/basemind/client/Client.kt
+++ b/sdks/android/sdk/src/main/kotlin/ai/basemind/client/Client.kt
@@ -23,27 +23,33 @@ internal const val ENV_API_GATEWAY_ADDRESS = "BASEMIND_API_GATEWAY_ADDRESS"
 internal const val ENV_API_GATEWAY_HTTPS = "BASEMIND_API_GATEWAY_HTTPS"
 internal const val ENV_API_GATEWAY_PORT = "BASEMIND_API_GATEWAY_PORT"
 internal const val LOGGING_TAG = "BaseMindClient"
+private const val DEFAULT_TERMINATION_DELAY_S = 5L
+
+@DslMarker
+annotation class BasemindClientDsl
 
 /**
  * BaseMindClient Options
  *
  * This dataclass is used for configuring the client.
  */
+
+@BasemindClientDsl
 data class Options(
     /**
      * The amount of seconds a channel shutdown should wait before force terminating requests.
      *
      * Defaults to 5 seconds.
      */
-    val terminationDelaySeconds: Long = 5L,
+    var terminationDelaySeconds: Long = DEFAULT_TERMINATION_DELAY_S,
     /**
      * Controls outputting debug log messages. Defaults to 'false'.
      */
-    val debug: Boolean = false,
+    var debug: Boolean = false,
     /**
      * A logging handler function. Defaults to android's Log.d.
      */
-    val debugLogger: (String, String) -> Unit = { tag, message -> Log.d(tag, message) },
+    var debugLogger: (String, String) -> Unit = { tag, message -> Log.d(tag, message) },
 )
 
 /**
@@ -60,7 +66,7 @@ class BaseMindClient(private val apiToken: String, private val options: Options 
     }
 
     private val channel =
-        let {
+        run {
             val serverAddress = System.getenv(ENV_API_GATEWAY_ADDRESS) ?: DEFAULT_API_GATEWAY_ADDRESS
             val serverPort = System.getenv(ENV_API_GATEWAY_PORT)?.toInt() ?: DEFAULT_API_GATEWAY_PORT
             val useHttps = System.getenv(ENV_API_GATEWAY_HTTPS)?.toBoolean() ?: DEFAULT_API_GATEWAY_HTTPS
@@ -130,7 +136,11 @@ class BaseMindClient(private val apiToken: String, private val options: Options 
             }
 
             when (e.status.code) {
-                io.grpc.Status.Code.INVALID_ARGUMENT -> throw MissingPromptVariableException(e.message ?: "Missing prompt variable", e)
+                io.grpc.Status.Code.INVALID_ARGUMENT -> throw MissingPromptVariableException(
+                    e.message ?: "Missing prompt variable",
+                    e,
+                )
+
                 else -> throw APIGatewayException(e.message ?: "API Gateway error", e)
             }
         }
@@ -156,7 +166,11 @@ class BaseMindClient(private val apiToken: String, private val options: Options 
             }
 
             when (e.status.code) {
-                io.grpc.Status.Code.INVALID_ARGUMENT -> throw MissingPromptVariableException(e.message ?: "Missing prompt variable", e)
+                io.grpc.Status.Code.INVALID_ARGUMENT -> throw MissingPromptVariableException(
+                    e.message ?: "Missing prompt variable",
+                    e,
+                )
+
                 else -> throw APIGatewayException(e.message ?: "API Gateway error", e)
             }
         }


### PR DESCRIPTION
- dsl for options
- replacing junit assertions with kotest
- test names can be ``` `test name` ``` instead of `test_name`
- use kotlin test and ```fun `test me`() = runTest{...}``` or use kotest