### PR TITLE
chore: updated serialization to use *json.RawMessage

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,7 @@
 default_stages: [commit]
 repos:
     - repo: https://github.com/alessandrojcm/commitlint-pre-commit-hook
-      rev: 'v9.7.0'
+      rev: 'v9.8.0'
       hooks:
           - id: commitlint
             stages: [commit-msg]
@@ -46,7 +46,7 @@ repos:
       hooks:
           - id: golines
     - repo: https://github.com/bufbuild/buf
-      rev: v1.27.2
+      rev: v1.28.0
       hooks:
           - id: buf-format
           - id: buf-lint

--- a/e2e/factories/factories.go
+++ b/e2e/factories/factories.go
@@ -3,10 +3,12 @@ package factories
 import (
 	"context"
 	"crypto/rand"
+	"encoding/json"
 	"fmt"
 	"github.com/basemind-ai/monorepo/shared/go/db/models"
 	"github.com/basemind-ai/monorepo/shared/go/exc"
 	"github.com/basemind-ai/monorepo/shared/go/serialization"
+	"k8s.io/utils/ptr"
 	"time"
 
 	"github.com/basemind-ai/monorepo/shared/go/datatypes"
@@ -24,7 +26,7 @@ func CreateOpenAIPromptMessages(
 	systemMessage string,
 	userMessage string,
 	templateVariables *[]string,
-) []byte {
+) *json.RawMessage {
 	msgs := []*datatypes.OpenAIPromptMessageDTO{{
 		Content: &systemMessage,
 		Role:    "system",
@@ -33,10 +35,10 @@ func CreateOpenAIPromptMessages(
 		Content:           &userMessage,
 		TemplateVariables: templateVariables,
 	}}
-	return serialization.SerializeJSON(msgs)
+	return ptr.To(json.RawMessage(serialization.SerializeJSON(msgs)))
 }
 
-func CreateModelParameters() []byte {
+func CreateModelParameters() *json.RawMessage {
 	modelParameters := serialization.SerializeJSON(map[string]float32{
 		"temperature":       1,
 		"top_p":             1,
@@ -45,7 +47,7 @@ func CreateModelParameters() []byte {
 		"frequency_penalty": 1,
 	})
 
-	return modelParameters
+	return ptr.To(json.RawMessage(modelParameters))
 }
 
 func CreateProject(ctx context.Context) (*models.Project, error) {
@@ -115,8 +117,8 @@ func CreatePromptConfig(
 		CreatePromptConfig(ctx, models.CreatePromptConfigParams{
 			ModelType:                 models.ModelTypeGpt35Turbo,
 			ModelVendor:               models.ModelVendorOPENAI,
-			ModelParameters:           modelParams,
-			ProviderPromptMessages:    promptMessages,
+			ModelParameters:           *modelParams,
+			ProviderPromptMessages:    *promptMessages,
 			ExpectedTemplateVariables: []string{"userInput"},
 			IsDefault:                 true,
 			ApplicationID:             applicationID,

--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/grpc-ecosystem/go-grpc-middleware/v2 v2.0.1
 	github.com/jackc/pgx/v5 v5.5.0
 	github.com/leg100/surl v0.0.6
-	github.com/lxzan/gws v1.6.13
+	github.com/lxzan/gws v1.6.14
 	github.com/ory/dockertest/v3 v3.10.0
 	github.com/redis/go-redis/v9 v9.3.0
 	github.com/rs/zerolog v1.31.0
@@ -124,7 +124,7 @@ require (
 	go.uber.org/multierr v1.11.0 // indirect
 	go.uber.org/zap v1.26.0 // indirect
 	golang.org/x/crypto v0.15.0 // indirect
-	golang.org/x/exp v0.0.0-20231108232855-2478ac86f678 // indirect
+	golang.org/x/exp v0.0.0-20231110203233-9a3e6036ecaa // indirect
 	golang.org/x/mod v0.14.0 // indirect
 	golang.org/x/net v0.18.0 // indirect
 	golang.org/x/oauth2 v0.14.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -547,8 +547,6 @@ cloud.google.com/go/storage v1.23.0/go.mod h1:vOEEDNFnciUMhBeT6hsJIn3ieU5cFRmzeL
 cloud.google.com/go/storage v1.27.0/go.mod h1:x9DOL8TK/ygDUMieqwfhdpQryTeEkhGKMi80i/iqR2s=
 cloud.google.com/go/storage v1.28.1/go.mod h1:Qnisd4CqDdo6BGs2AD5LLnEsmSQ80wQ5ogcBBKhU86Y=
 cloud.google.com/go/storage v1.29.0/go.mod h1:4puEjyTKnku6gfKoTfNOU/W+a9JyuVNxjpS5GBrB8h4=
-cloud.google.com/go/storage v1.34.1 h1:H2Af2dU5J0PF7A5B+ECFIce+RqxVnrVilO+cu0TS3MI=
-cloud.google.com/go/storage v1.34.1/go.mod h1:VN1ElqqvR9adg1k9xlkUJ55cMOP1/QjnNNuT5xQL6dY=
 cloud.google.com/go/storage v1.35.1 h1:B59ahL//eDfx2IIKFBeT5Atm9wnNmj3+8xG/W4WB//w=
 cloud.google.com/go/storage v1.35.1/go.mod h1:M6M/3V/D3KpzMTJyPOR/HU6n2Si5QdaXYEsng2xgOs8=
 cloud.google.com/go/storagetransfer v1.5.0/go.mod h1:dxNzUopWy7RQevYFHewchb29POFv3/AaBgnhqzqiK0w=
@@ -970,6 +968,8 @@ github.com/lufia/plan9stats v0.0.0-20231016141302-07b5767bb0ed h1:036IscGBfJsFIg
 github.com/lufia/plan9stats v0.0.0-20231016141302-07b5767bb0ed/go.mod h1:ilwx/Dta8jXAgpFYFvSWEMwxmbWXyiUHkd5FwyKhb5k=
 github.com/lxzan/gws v1.6.13 h1:85UaBsL5alQOiDao0tlupZYSJCl1Yp6u+un/VHLkVfY=
 github.com/lxzan/gws v1.6.13/go.mod h1:dsC6S7kJNh+iWqqu2HiO8tnNCji04HwyJCYfTOS+6iY=
+github.com/lxzan/gws v1.6.14 h1:12fhyb8ThRiFhetxUqVhq8hm5vmm4tYcrMnpY6m1Q14=
+github.com/lxzan/gws v1.6.14/go.mod h1:dsC6S7kJNh+iWqqu2HiO8tnNCji04HwyJCYfTOS+6iY=
 github.com/lyft/protoc-gen-star v0.6.0/go.mod h1:TGAoBVkt8w7MPG72TrKIu85MIdXwDuzJYeZuUPFPNwA=
 github.com/lyft/protoc-gen-star v0.6.1/go.mod h1:TGAoBVkt8w7MPG72TrKIu85MIdXwDuzJYeZuUPFPNwA=
 github.com/lyft/protoc-gen-star/v2 v2.0.1/go.mod h1:RcCdONR2ScXaYnQC5tUzxzlpA3WVYF7/opLeUgcQs/o=
@@ -1199,6 +1199,8 @@ golang.org/x/exp v0.0.0-20200224162631-6cc2880d07d6/go.mod h1:3jZMyOhIsHpP37uCMk
 golang.org/x/exp v0.0.0-20220827204233-334a2380cb91/go.mod h1:cyybsKvd6eL0RnXn6p/Grxp8F5bW7iYuBgsNCOHpMYE=
 golang.org/x/exp v0.0.0-20231108232855-2478ac86f678 h1:mchzmB1XO2pMaKFRqk/+MV3mgGG96aqaPXaMifQU47w=
 golang.org/x/exp v0.0.0-20231108232855-2478ac86f678/go.mod h1:zk2irFbV9DP96SEBUUAy67IdHUaZuSnrz1n472HUCLE=
+golang.org/x/exp v0.0.0-20231110203233-9a3e6036ecaa h1:FRnLl4eNAQl8hwxVVC17teOw8kdjVDVAiFMtgUdTSRQ=
+golang.org/x/exp v0.0.0-20231110203233-9a3e6036ecaa/go.mod h1:zk2irFbV9DP96SEBUUAy67IdHUaZuSnrz1n472HUCLE=
 golang.org/x/image v0.0.0-20180708004352-c73c2afc3b81/go.mod h1:ux5Hcp/YLpHSI86hEcLt0YII63i6oz57MZXIpbrjZUs=
 golang.org/x/image v0.0.0-20190227222117-0694c2d4d067/go.mod h1:kZ7UVZpmo3dzQBMxlp+ypCbDeSB+sBbTgSJuh5dn5js=
 golang.org/x/image v0.0.0-20190802002840-cff245a6509b/go.mod h1:FeLwcggjj3mMvU+oOTbSwawSJRM1uh48EjtB4UJZlP0=

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
 		"test": "vitest"
 	},
 	"devDependencies": {
-		"@bufbuild/buf": "^1.27.2",
+		"@bufbuild/buf": "^1.28.0",
 		"@commitlint/cli": "^18.4.0",
 		"@commitlint/config-conventional": "^18.4.0",
 		"@faker-js/faker": "^8.2.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,8 +8,8 @@ importers:
     .:
         devDependencies:
             '@bufbuild/buf':
-                specifier: ^1.27.2
-                version: 1.27.2
+                specifier: ^1.28.0
+                version: 1.28.0
             '@commitlint/cli':
                 specifier: ^18.4.0
                 version: 18.4.0(typescript@5.2.2)
@@ -312,8 +312,8 @@ importers:
                 specifier: ^2.0.0
                 version: 2.0.0
             openai:
-                specifier: ^4.17.3
-                version: 4.17.3
+                specifier: ^4.17.4
+                version: 4.17.4
             pino:
                 specifier: ^8.16.1
                 version: 8.16.1
@@ -2151,10 +2151,10 @@ packages:
             }
         dev: true
 
-    /@bufbuild/buf-darwin-arm64@1.27.2:
+    /@bufbuild/buf-darwin-arm64@1.28.0:
         resolution:
             {
-                integrity: sha512-ob1IAhFVsAVUr5o4EAwoeQ6FOGJdiS6eYGTGQiZzJEAYSs2dX/WQ9+Xz9EPQUb93n7PMjNs38DLDfwGQ3u3dsg==,
+                integrity: sha512-trbnKKCINrRUXf0Rs88QmniZeQ4ODdsA9yISOj5JdeVDr9rQf1j/P2NUM+JimQpLm78I1CRR5qQPIX3Q8xR0NA==,
             }
         engines: { node: '>=12' }
         cpu: [arm64]
@@ -2163,10 +2163,10 @@ packages:
         dev: true
         optional: true
 
-    /@bufbuild/buf-darwin-x64@1.27.2:
+    /@bufbuild/buf-darwin-x64@1.28.0:
         resolution:
             {
-                integrity: sha512-Kp0HBvLjeOxJtZ/j3vOulX6G3u5pa9vksVmJ5HGjhL0BZJwavh8Bd9YgrBDrTzKtTQMHxmhTSaNEgNUWkjecfw==,
+                integrity: sha512-AVhGVJjaR26Qe0gNv+3AijeaQABJyFY8tlInEOOtTaQi2UGR8cgQoYBCziL3NQfH06wi7nEwTJm/ej2JUpAt2Q==,
             }
         engines: { node: '>=12' }
         cpu: [x64]
@@ -2175,10 +2175,10 @@ packages:
         dev: true
         optional: true
 
-    /@bufbuild/buf-linux-aarch64@1.27.2:
+    /@bufbuild/buf-linux-aarch64@1.28.0:
         resolution:
             {
-                integrity: sha512-rq+bpT+FMR1iiUvcHno1SPS4e0Ydr+F7ArIzN5cO4DKL09sBJXcaVGa7fRRlBZvNJTt3XRVtlE8LNLGH7zjBOg==,
+                integrity: sha512-5qzLdO2MpXHPh2W5Rlf58oW8iH+wwOIjQs3vlgtgeI0nGu0FhRgpcrJ1E0lswTUE0NW19RMLI+q/QpjEl9W3aw==,
             }
         engines: { node: '>=12' }
         cpu: [arm64]
@@ -2187,10 +2187,10 @@ packages:
         dev: true
         optional: true
 
-    /@bufbuild/buf-linux-x64@1.27.2:
+    /@bufbuild/buf-linux-x64@1.28.0:
         resolution:
             {
-                integrity: sha512-t/lcJ06gELy+4hVROuoeX8Y+oXq9NrPX+UgT5WujGo21oOb8UAQETZLRefj2U4IRqYqXhTKicfOI2y8xI7CSlQ==,
+                integrity: sha512-gZm7vGjhcabb1Zqp+ARYiJYCNm2mtbXFqo9Cqy0hpaonWaKAn7lbjtT0tG7rVX++QIfOpE3CwnjUNHck5xKP6A==,
             }
         engines: { node: '>=12' }
         cpu: [x64]
@@ -2199,10 +2199,10 @@ packages:
         dev: true
         optional: true
 
-    /@bufbuild/buf-win32-arm64@1.27.2:
+    /@bufbuild/buf-win32-arm64@1.28.0:
         resolution:
             {
-                integrity: sha512-rJieGmtSw4tfteW6mhjdtDDTFBbl2HBan1FnfNAOZH4ZrTwfcOO5Vn3fUMl+jPtiCpTscyzVaYHI+LvYffSdvg==,
+                integrity: sha512-ptIfiTYW2cMlPOcnkz3YF/aSR9ztAzeozycv460qDR0p0c0KYHKRTTFKD8TRahoyU7znmWEluYBdmKZAbbtwKg==,
             }
         engines: { node: '>=12' }
         cpu: [arm64]
@@ -2211,10 +2211,10 @@ packages:
         dev: true
         optional: true
 
-    /@bufbuild/buf-win32-x64@1.27.2:
+    /@bufbuild/buf-win32-x64@1.28.0:
         resolution:
             {
-                integrity: sha512-x9IKCHgj6GmDGH2xlTo80l2feNU3hUeoEwLFLH4I5Qs2L1gfYIDMZGp+0Bhm5eK9CIWYtkJqeqGRIJkrJA6CfQ==,
+                integrity: sha512-vwjMUfelrB8RD/xHdR6MVEl9XqIxvASvzj0szz70hvQmzmU4BEOEUTHtERMOnBJxiPE1a28YEfpUlxyvm+COCg==,
             }
         engines: { node: '>=12' }
         cpu: [x64]
@@ -2223,21 +2223,21 @@ packages:
         dev: true
         optional: true
 
-    /@bufbuild/buf@1.27.2:
+    /@bufbuild/buf@1.28.0:
         resolution:
             {
-                integrity: sha512-hwZYF0DCxvmTAZIAeT/q66HYtIxnSH9jn/CVElaJA/l+Clr9zhLdfKFd1yD2lMqHpNUEeXtA8T0ABXv29NVfYQ==,
+                integrity: sha512-QizjughxiWj53BTFijxQN5YDCcIriLAsCSYgxk+l9YzEC3hHAjCBen0hGJcSezWDLKWiGxAD6AMXiRIfAHKZjQ==,
             }
         engines: { node: '>=12' }
         hasBin: true
         requiresBuild: true
         optionalDependencies:
-            '@bufbuild/buf-darwin-arm64': 1.27.2
-            '@bufbuild/buf-darwin-x64': 1.27.2
-            '@bufbuild/buf-linux-aarch64': 1.27.2
-            '@bufbuild/buf-linux-x64': 1.27.2
-            '@bufbuild/buf-win32-arm64': 1.27.2
-            '@bufbuild/buf-win32-x64': 1.27.2
+            '@bufbuild/buf-darwin-arm64': 1.28.0
+            '@bufbuild/buf-darwin-x64': 1.28.0
+            '@bufbuild/buf-linux-aarch64': 1.28.0
+            '@bufbuild/buf-linux-x64': 1.28.0
+            '@bufbuild/buf-win32-arm64': 1.28.0
+            '@bufbuild/buf-win32-x64': 1.28.0
         dev: true
 
     /@colors/colors@1.5.0:
@@ -8827,7 +8827,7 @@ packages:
         hasBin: true
         dependencies:
             caniuse-lite: 1.0.30001561
-            electron-to-chromium: 1.4.580
+            electron-to-chromium: 1.4.581
             node-releases: 2.0.13
             update-browserslist-db: 1.0.13(browserslist@4.22.1)
 
@@ -10524,10 +10524,10 @@ packages:
             jake: 10.8.7
         dev: true
 
-    /electron-to-chromium@1.4.580:
+    /electron-to-chromium@1.4.581:
         resolution:
             {
-                integrity: sha512-T5q3pjQon853xxxHUq3ZP68ZpvJHuSMY2+BZaW3QzjS4HvNuvsMmZ/+lU+nCrftre1jFZ+OSlExynXWBihnXzw==,
+                integrity: sha512-6uhqWBIapTJUxgPTCHH9sqdbxIMPt7oXl0VcAL1kOtlU6aECdcMncCrX5Z7sHQ/invtrC9jUQUef7+HhO8vVFw==,
             }
 
     /elliptic@6.5.4:
@@ -15459,10 +15459,10 @@ packages:
             is-wsl: 2.2.0
         dev: true
 
-    /openai@4.17.3:
+    /openai@4.17.4:
         resolution:
             {
-                integrity: sha512-Gx9wzl9HWX5pjagkgXVu6U2BTFEPkQFdkppNnAX2n2Rpjtn2zt152wXh7NnZ5eJuVxUGYzRe66JmayAEGjzqAg==,
+                integrity: sha512-ThRFkl6snLbcAKS58St7N3CaKuI5WdYUvIjPvf4s+8SdymgNtOfzmZcZXVcCefx04oKFnvZJvIcTh3eAFUUhAQ==,
             }
         hasBin: true
         dependencies:

--- a/services/api-gateway/internal/connectors/openai/request_test.go
+++ b/services/api-gateway/internal/connectors/openai/request_test.go
@@ -2,6 +2,7 @@ package openai_test
 
 import (
 	"context"
+	"encoding/json"
 	"github.com/basemind-ai/monorepo/e2e/factories"
 	openaiconnector "github.com/basemind-ai/monorepo/gen/go/openai/v1"
 	"github.com/basemind-ai/monorepo/services/api-gateway/internal/dto"
@@ -9,6 +10,7 @@ import (
 	"github.com/basemind-ai/monorepo/shared/go/datatypes"
 	"github.com/basemind-ai/monorepo/shared/go/db"
 	"github.com/stretchr/testify/assert"
+	"k8s.io/utils/ptr"
 	"testing"
 )
 
@@ -38,8 +40,8 @@ func TestRequestPrompt(t *testing.T) {
 			Name:                      promptConfig.Name,
 			ModelType:                 promptConfig.ModelType,
 			ModelVendor:               promptConfig.ModelVendor,
-			ModelParameters:           promptConfig.ModelParameters,
-			ProviderPromptMessages:    promptConfig.ProviderPromptMessages,
+			ModelParameters:           ptr.To(json.RawMessage(promptConfig.ModelParameters)),
+			ProviderPromptMessages:    ptr.To(json.RawMessage(promptConfig.ProviderPromptMessages)),
 			ExpectedTemplateVariables: promptConfig.ExpectedTemplateVariables,
 			IsDefault:                 promptConfig.IsDefault,
 			CreatedAt:                 promptConfig.CreatedAt.Time,

--- a/services/api-gateway/internal/connectors/openai/stream_test.go
+++ b/services/api-gateway/internal/connectors/openai/stream_test.go
@@ -2,6 +2,7 @@ package openai_test
 
 import (
 	"context"
+	"encoding/json"
 	"github.com/basemind-ai/monorepo/e2e/factories"
 	openaiconnector "github.com/basemind-ai/monorepo/gen/go/openai/v1"
 	"github.com/basemind-ai/monorepo/services/api-gateway/internal/dto"
@@ -9,6 +10,7 @@ import (
 	"github.com/basemind-ai/monorepo/shared/go/datatypes"
 	"github.com/basemind-ai/monorepo/shared/go/db"
 	"github.com/stretchr/testify/assert"
+	"k8s.io/utils/ptr"
 	"testing"
 )
 
@@ -35,8 +37,8 @@ func TestRequestStream(t *testing.T) {
 			Name:                      promptConfig.Name,
 			ModelType:                 promptConfig.ModelType,
 			ModelVendor:               promptConfig.ModelVendor,
-			ModelParameters:           promptConfig.ModelParameters,
-			ProviderPromptMessages:    promptConfig.ProviderPromptMessages,
+			ModelParameters:           ptr.To(json.RawMessage(promptConfig.ModelParameters)),
+			ProviderPromptMessages:    ptr.To(json.RawMessage(promptConfig.ProviderPromptMessages)),
 			ExpectedTemplateVariables: promptConfig.ExpectedTemplateVariables,
 			IsDefault:                 promptConfig.IsDefault,
 			CreatedAt:                 promptConfig.CreatedAt.Time,

--- a/services/api-gateway/internal/connectors/openai/utils.go
+++ b/services/api-gateway/internal/connectors/openai/utils.go
@@ -74,8 +74,8 @@ func ParseTemplateVariables(
 func CreatePromptRequest(
 	applicationID pgtype.UUID,
 	modelType models.ModelType,
-	modelParameters []byte,
-	promptMessages []byte,
+	modelParameters *json.RawMessage,
+	promptMessages *json.RawMessage,
 	templateVariables map[string]string,
 ) (*openaiconnector.OpenAIPromptRequest, error) {
 	model, modelErr := GetModelType(modelType)
@@ -93,14 +93,14 @@ func CreatePromptRequest(
 	}
 
 	if parametersUnmarshalErr := json.Unmarshal(
-		modelParameters,
+		*modelParameters,
 		promptRequest.Parameters,
 	); parametersUnmarshalErr != nil {
 		return nil, fmt.Errorf("failed to unmarshal model parameters - %w", parametersUnmarshalErr)
 	}
 
 	var openAIPromptMessageDTOs []*datatypes.OpenAIPromptMessageDTO
-	if messagesUnmarshalErr := json.Unmarshal(promptMessages, &openAIPromptMessageDTOs); messagesUnmarshalErr != nil {
+	if messagesUnmarshalErr := json.Unmarshal(*promptMessages, &openAIPromptMessageDTOs); messagesUnmarshalErr != nil {
 		return nil, fmt.Errorf("failed to unmarshal prompt messages - %w", messagesUnmarshalErr)
 	}
 

--- a/services/api-gateway/internal/services/apigateway_test.go
+++ b/services/api-gateway/internal/services/apigateway_test.go
@@ -2,6 +2,7 @@ package services_test
 
 import (
 	"context"
+	"encoding/json"
 	"github.com/basemind-ai/monorepo/e2e/factories"
 	"github.com/basemind-ai/monorepo/gen/go/gateway/v1"
 	"github.com/basemind-ai/monorepo/services/api-gateway/internal/dto"
@@ -14,6 +15,7 @@ import (
 	"github.com/jackc/pgx/v5/pgtype"
 	"github.com/stretchr/testify/assert"
 	"google.golang.org/grpc"
+	"k8s.io/utils/ptr"
 	"testing"
 	"time"
 )
@@ -40,8 +42,8 @@ func createRequestConfigurationDTO(
 			Name:                      promptConfig.Name,
 			ModelType:                 promptConfig.ModelType,
 			ModelVendor:               promptConfig.ModelVendor,
-			ModelParameters:           promptConfig.ModelParameters,
-			ProviderPromptMessages:    promptConfig.ProviderPromptMessages,
+			ModelParameters:           ptr.To(json.RawMessage(promptConfig.ModelParameters)),
+			ProviderPromptMessages:    ptr.To(json.RawMessage(promptConfig.ProviderPromptMessages)),
 			ExpectedTemplateVariables: promptConfig.ExpectedTemplateVariables,
 			IsDefault:                 promptConfig.IsDefault,
 			CreatedAt:                 promptConfig.CreatedAt.Time,

--- a/services/api-gateway/internal/services/integration_test.go
+++ b/services/api-gateway/internal/services/integration_test.go
@@ -277,10 +277,10 @@ func TestIntegration(t *testing.T) { //nolint: revive
 					TemplateVariables:         templateVariables,
 					ExpectedTemplateVariables: expectedTemplateVariables,
 					ApplicationId:             applicationID,
-					ModelParameters:           modelParameters,
+					ModelParameters:           *modelParameters,
 					ModelVendor:               string(models.ModelVendorOPENAI),
 					ModelType:                 string(models.ModelTypeGpt432k),
-					ProviderPromptMessages:    promptMessages,
+					ProviderPromptMessages:    *promptMessages,
 					PromptConfigId:            promptConfigID,
 				})
 				assert.NoError(t, streamErr)

--- a/services/api-gateway/internal/services/prompttesting.go
+++ b/services/api-gateway/internal/services/prompttesting.go
@@ -1,6 +1,7 @@
 package services
 
 import (
+	"encoding/json"
 	"fmt"
 	"github.com/basemind-ai/monorepo/gen/go/ptesting/v1"
 	"github.com/basemind-ai/monorepo/services/api-gateway/internal/connectors"
@@ -8,6 +9,7 @@ import (
 	"github.com/basemind-ai/monorepo/shared/go/datatypes"
 	"github.com/basemind-ai/monorepo/shared/go/db"
 	"github.com/basemind-ai/monorepo/shared/go/db/models"
+	"k8s.io/utils/ptr"
 )
 
 type PromptTestingServer struct {
@@ -41,10 +43,10 @@ func (PromptTestingServer) TestPrompt(
 		PromptConfigID: *promptConfigID,
 		PromptConfigData: datatypes.PromptConfigDTO{
 			ID:                        request.PromptConfigId,
-			ModelParameters:           request.ModelParameters,
+			ModelParameters:           ptr.To(json.RawMessage(request.ModelParameters)),
 			ModelType:                 models.ModelType(request.ModelType),
 			ModelVendor:               models.ModelVendor(request.ModelVendor),
-			ProviderPromptMessages:    request.ProviderPromptMessages,
+			ProviderPromptMessages:    ptr.To(json.RawMessage(request.ProviderPromptMessages)),
 			ExpectedTemplateVariables: request.ExpectedTemplateVariables,
 		},
 		ProviderModelPricing: modelPricing,

--- a/services/api-gateway/internal/services/prompttesting_test.go
+++ b/services/api-gateway/internal/services/prompttesting_test.go
@@ -75,8 +75,8 @@ func TestPromptTestingService(t *testing.T) {
 			mock := MockPromptTestingServerStream{Ctx: context.TODO()}
 			err := srv.TestPrompt(&ptesting.PromptTestRequest{
 				ApplicationId:          invalidUUID,
-				ModelParameters:        modelParameters,
-				ProviderPromptMessages: promptMessages,
+				ModelParameters:        *modelParameters,
+				ProviderPromptMessages: *promptMessages,
 				PromptConfigId:         promptConfigID,
 				TemplateVariables:      nil,
 				ModelVendor:            string(models.ModelVendorOPENAI),
@@ -88,8 +88,8 @@ func TestPromptTestingService(t *testing.T) {
 			mock := MockPromptTestingServerStream{Ctx: context.TODO()}
 			err := srv.TestPrompt(&ptesting.PromptTestRequest{
 				ApplicationId:          "38c8e86d-0027-4c99-ba34-82c77e5cd145",
-				ModelParameters:        modelParameters,
-				ProviderPromptMessages: promptMessages,
+				ModelParameters:        *modelParameters,
+				ProviderPromptMessages: *promptMessages,
 				PromptConfigId:         invalidUUID,
 				TemplateVariables:      nil,
 				ModelVendor:            string(models.ModelVendorOPENAI),

--- a/services/api-gateway/internal/services/utils.go
+++ b/services/api-gateway/internal/services/utils.go
@@ -2,6 +2,7 @@ package services
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"github.com/basemind-ai/monorepo/gen/go/gateway/v1"
 	"github.com/basemind-ai/monorepo/services/api-gateway/internal/dto"
@@ -14,6 +15,7 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
+	"k8s.io/utils/ptr"
 )
 
 // RetrievePromptConfig retrieves the prompt config - either using the provided ID, or the application default.
@@ -38,10 +40,10 @@ func RetrievePromptConfig(
 		return &datatypes.PromptConfigDTO{
 			ID:                        db.UUIDToString(&promptConfig.ID),
 			Name:                      promptConfig.Name,
-			ModelParameters:           promptConfig.ModelParameters,
+			ModelParameters:           ptr.To(json.RawMessage(promptConfig.ModelParameters)),
 			ModelType:                 promptConfig.ModelType,
 			ModelVendor:               promptConfig.ModelVendor,
-			ProviderPromptMessages:    promptConfig.ProviderPromptMessages,
+			ProviderPromptMessages:    ptr.To(json.RawMessage(promptConfig.ProviderPromptMessages)),
 			ExpectedTemplateVariables: promptConfig.ExpectedTemplateVariables,
 			IsDefault:                 promptConfig.IsDefault,
 			CreatedAt:                 promptConfig.CreatedAt.Time,
@@ -62,10 +64,10 @@ func RetrievePromptConfig(
 	return &datatypes.PromptConfigDTO{
 		ID:                        db.UUIDToString(&promptConfig.ID),
 		Name:                      promptConfig.Name,
-		ModelParameters:           promptConfig.ModelParameters,
+		ModelParameters:           ptr.To(json.RawMessage(promptConfig.ModelParameters)),
 		ModelType:                 promptConfig.ModelType,
 		ModelVendor:               promptConfig.ModelVendor,
-		ProviderPromptMessages:    promptConfig.ProviderPromptMessages,
+		ProviderPromptMessages:    ptr.To(json.RawMessage(promptConfig.ProviderPromptMessages)),
 		ExpectedTemplateVariables: promptConfig.ExpectedTemplateVariables,
 		IsDefault:                 promptConfig.IsDefault,
 		CreatedAt:                 promptConfig.CreatedAt.Time,

--- a/services/api-gateway/internal/services/utils_test.go
+++ b/services/api-gateway/internal/services/utils_test.go
@@ -37,12 +37,12 @@ func TestUtils(t *testing.T) { //nolint:revive
 			assert.Equal(
 				t,
 				promptConfig.ModelParameters,
-				promptConfigDTO.ModelParameters,
+				[]byte(*promptConfigDTO.ModelParameters),
 			)
 			assert.Equal(
 				t,
 				promptConfig.ProviderPromptMessages,
-				promptConfigDTO.ProviderPromptMessages,
+				[]byte(*promptConfigDTO.ProviderPromptMessages),
 			)
 			assert.Equal(
 				t,
@@ -87,12 +87,12 @@ func TestUtils(t *testing.T) { //nolint:revive
 				assert.Equal(
 					t,
 					promptConfig.ModelParameters,
-					promptConfigDTO.ModelParameters,
+					[]byte(*promptConfigDTO.ModelParameters),
 				)
 				assert.Equal(
 					t,
 					promptConfig.ProviderPromptMessages,
-					promptConfigDTO.ProviderPromptMessages,
+					[]byte(*promptConfigDTO.ProviderPromptMessages),
 				)
 				assert.Equal(
 					t,
@@ -173,12 +173,12 @@ func TestUtils(t *testing.T) { //nolint:revive
 			assert.Equal(
 				t,
 				promptConfig.ModelParameters,
-				requestConfigurationDTO.PromptConfigData.ModelParameters,
+				[]byte(*requestConfigurationDTO.PromptConfigData.ModelParameters),
 			)
 			assert.Equal(
 				t,
 				promptConfig.ProviderPromptMessages,
-				requestConfigurationDTO.PromptConfigData.ProviderPromptMessages,
+				[]byte(*requestConfigurationDTO.PromptConfigData.ProviderPromptMessages),
 			)
 			assert.Equal(
 				t,

--- a/services/dashboard-backend/internal/api/promptconfigs_test.go
+++ b/services/dashboard-backend/internal/api/promptconfigs_test.go
@@ -2,9 +2,11 @@ package api_test
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"github.com/basemind-ai/monorepo/services/dashboard-backend/internal/api"
 	"github.com/basemind-ai/monorepo/shared/go/db/models"
+	"k8s.io/utils/ptr"
 	"net/http"
 	"strings"
 	"testing"
@@ -287,8 +289,8 @@ func TestPromptConfigAPI(t *testing.T) { //nolint: revive
 						Name:                      "unique name",
 						ModelVendor:               models.ModelVendorOPENAI,
 						ModelType:                 models.ModelTypeGpt4,
-						ModelParameters:           modelParameters,
-						ProviderPromptMessages:    promptMessages,
+						ModelParameters:           *modelParameters,
+						ProviderPromptMessages:    *promptMessages,
 						ExpectedTemplateVariables: []string{"userInput"},
 						IsDefault:                 true,
 					})
@@ -318,8 +320,8 @@ func TestPromptConfigAPI(t *testing.T) { //nolint: revive
 					Name:                      "default prompt config",
 					ModelVendor:               models.ModelVendorOPENAI,
 					ModelType:                 models.ModelTypeGpt4,
-					ModelParameters:           modelParameters,
-					ProviderPromptMessages:    promptMessages,
+					ModelParameters:           *modelParameters,
+					ProviderPromptMessages:    *promptMessages,
 					ExpectedTemplateVariables: []string{"userInput"},
 					IsDefault:                 true,
 				})
@@ -428,8 +430,8 @@ func TestPromptConfigAPI(t *testing.T) { //nolint: revive
 					Name:                      "a",
 					ModelVendor:               models.ModelVendorOPENAI,
 					ModelType:                 models.ModelTypeGpt4,
-					ModelParameters:           modelParameters,
-					ProviderPromptMessages:    promptMessages,
+					ModelParameters:           *modelParameters,
+					ProviderPromptMessages:    *promptMessages,
 					ExpectedTemplateVariables: []string{"name"},
 					IsDefault:                 true,
 				})
@@ -440,8 +442,8 @@ func TestPromptConfigAPI(t *testing.T) { //nolint: revive
 					Name:                      "b",
 					ModelVendor:               models.ModelVendorOPENAI,
 					ModelType:                 models.ModelTypeGpt4,
-					ModelParameters:           modelParameters,
-					ProviderPromptMessages:    promptMessages,
+					ModelParameters:           *modelParameters,
+					ProviderPromptMessages:    *promptMessages,
 					ExpectedTemplateVariables: []string{"values"},
 					IsDefault:                 true,
 				})
@@ -577,8 +579,8 @@ func TestPromptConfigAPI(t *testing.T) { //nolint: revive
 					Name:                      factories.RandomString(10),
 					ModelVendor:               models.ModelVendorOPENAI,
 					ModelType:                 models.ModelTypeGpt4,
-					ModelParameters:           modelParameters,
-					ProviderPromptMessages:    promptMessages,
+					ModelParameters:           *modelParameters,
+					ProviderPromptMessages:    *promptMessages,
 					ExpectedTemplateVariables: []string{""},
 					IsDefault:                 true,
 				})
@@ -590,8 +592,8 @@ func TestPromptConfigAPI(t *testing.T) { //nolint: revive
 					Name:                      factories.RandomString(10),
 					ModelVendor:               models.ModelVendorOPENAI,
 					ModelType:                 models.ModelTypeGpt4,
-					ModelParameters:           modelParameters,
-					ProviderPromptMessages:    promptMessages,
+					ModelParameters:           *modelParameters,
+					ProviderPromptMessages:    *promptMessages,
 					ExpectedTemplateVariables: []string{""},
 					IsDefault:                 false,
 				})
@@ -632,8 +634,8 @@ func TestPromptConfigAPI(t *testing.T) { //nolint: revive
 					Name:                      factories.RandomString(10),
 					ModelVendor:               models.ModelVendorOPENAI,
 					ModelType:                 models.ModelTypeGpt4,
-					ModelParameters:           modelParameters,
-					ProviderPromptMessages:    promptMessages,
+					ModelParameters:           *modelParameters,
+					ProviderPromptMessages:    *promptMessages,
 					ExpectedTemplateVariables: []string{""},
 					IsDefault:                 true,
 				})
@@ -645,8 +647,8 @@ func TestPromptConfigAPI(t *testing.T) { //nolint: revive
 					Name:                      factories.RandomString(10),
 					ModelVendor:               models.ModelVendorOPENAI,
 					ModelType:                 models.ModelTypeGpt4,
-					ModelParameters:           modelParameters,
-					ProviderPromptMessages:    promptMessages,
+					ModelParameters:           *modelParameters,
+					ProviderPromptMessages:    *promptMessages,
 					ExpectedTemplateVariables: []string{""},
 					IsDefault:                 false,
 				})
@@ -690,8 +692,8 @@ func TestPromptConfigAPI(t *testing.T) { //nolint: revive
 						Name:                      factories.RandomString(10),
 						ModelVendor:               models.ModelVendorOPENAI,
 						ModelType:                 models.ModelTypeGpt4,
-						ModelParameters:           modelParameters,
-						ProviderPromptMessages:    promptMessages,
+						ModelParameters:           *modelParameters,
+						ProviderPromptMessages:    *promptMessages,
 						ExpectedTemplateVariables: []string{""},
 						IsDefault:                 true,
 					})
@@ -703,8 +705,8 @@ func TestPromptConfigAPI(t *testing.T) { //nolint: revive
 						Name:                      factories.RandomString(10),
 						ModelVendor:               models.ModelVendorOPENAI,
 						ModelType:                 models.ModelTypeGpt4,
-						ModelParameters:           modelParameters,
-						ProviderPromptMessages:    promptMessages,
+						ModelParameters:           *modelParameters,
+						ProviderPromptMessages:    *promptMessages,
 						ExpectedTemplateVariables: []string{""},
 						IsDefault:                 false,
 					})
@@ -745,8 +747,8 @@ func TestPromptConfigAPI(t *testing.T) { //nolint: revive
 						Name:                      factories.RandomString(10),
 						ModelVendor:               models.ModelVendorOPENAI,
 						ModelType:                 models.ModelTypeGpt4,
-						ModelParameters:           modelParameters,
-						ProviderPromptMessages:    promptMessages,
+						ModelParameters:           *modelParameters,
+						ProviderPromptMessages:    *promptMessages,
 						ExpectedTemplateVariables: []string{""},
 						IsDefault:                 true,
 					})
@@ -758,8 +760,8 @@ func TestPromptConfigAPI(t *testing.T) { //nolint: revive
 						Name:                      factories.RandomString(10),
 						ModelVendor:               models.ModelVendorOPENAI,
 						ModelType:                 models.ModelTypeGpt4,
-						ModelParameters:           modelParameters,
-						ProviderPromptMessages:    promptMessages,
+						ModelParameters:           *modelParameters,
+						ProviderPromptMessages:    *promptMessages,
 						ExpectedTemplateVariables: []string{""},
 						IsDefault:                 false,
 					})
@@ -799,8 +801,8 @@ func TestPromptConfigAPI(t *testing.T) { //nolint: revive
 						Name:                      "default prompt config",
 						ModelVendor:               models.ModelVendorOPENAI,
 						ModelType:                 models.ModelTypeGpt4,
-						ModelParameters:           modelParameters,
-						ProviderPromptMessages:    promptMessages,
+						ModelParameters:           *modelParameters,
+						ProviderPromptMessages:    *promptMessages,
 						ExpectedTemplateVariables: []string{""},
 						IsDefault:                 true,
 					})
@@ -888,8 +890,8 @@ func TestPromptConfigAPI(t *testing.T) { //nolint: revive
 					Name:                      "abc prompt config",
 					ModelVendor:               models.ModelVendorOPENAI,
 					ModelType:                 models.ModelTypeGpt4,
-					ModelParameters:           modelParameters,
-					ProviderPromptMessages:    promptMessages,
+					ModelParameters:           *modelParameters,
+					ProviderPromptMessages:    *promptMessages,
 					ExpectedTemplateVariables: []string{""},
 					IsDefault:                 true,
 				})
@@ -926,8 +928,8 @@ func TestPromptConfigAPI(t *testing.T) { //nolint: revive
 						Name:                      "abc prompt config",
 						ModelVendor:               models.ModelVendorOPENAI,
 						ModelType:                 models.ModelTypeGpt4,
-						ModelParameters:           modelParameters,
-						ProviderPromptMessages:    promptMessages,
+						ModelParameters:           *modelParameters,
+						ProviderPromptMessages:    *promptMessages,
 						ExpectedTemplateVariables: []string{""},
 						IsDefault:                 true,
 					})
@@ -971,8 +973,8 @@ func TestPromptConfigAPI(t *testing.T) { //nolint: revive
 						Name:                      "abc prompt config",
 						ModelVendor:               models.ModelVendorOPENAI,
 						ModelType:                 models.ModelTypeGpt4,
-						ModelParameters:           modelParameters,
-						ProviderPromptMessages:    promptMessages,
+						ModelParameters:           *modelParameters,
+						ProviderPromptMessages:    *promptMessages,
 						ExpectedTemplateVariables: []string{""},
 						IsDefault:                 true,
 					})
@@ -1006,8 +1008,8 @@ func TestPromptConfigAPI(t *testing.T) { //nolint: revive
 						Name:                      factories.RandomString(10),
 						ModelVendor:               models.ModelVendorOPENAI,
 						ModelType:                 models.ModelTypeGpt4,
-						ModelParameters:           modelParameters,
-						ProviderPromptMessages:    promptMessages,
+						ModelParameters:           *modelParameters,
+						ProviderPromptMessages:    *promptMessages,
 						ExpectedTemplateVariables: []string{""},
 						IsDefault:                 true,
 					})
@@ -1035,8 +1037,8 @@ func TestPromptConfigAPI(t *testing.T) { //nolint: revive
 						Name:                      factories.RandomString(10),
 						ModelVendor:               models.ModelVendorOPENAI,
 						ModelType:                 models.ModelTypeGpt4,
-						ModelParameters:           modelParameters,
-						ProviderPromptMessages:    promptMessages,
+						ModelParameters:           *modelParameters,
+						ProviderPromptMessages:    *promptMessages,
 						ExpectedTemplateVariables: []string{""},
 						IsDefault:                 true,
 					})
@@ -1048,8 +1050,8 @@ func TestPromptConfigAPI(t *testing.T) { //nolint: revive
 						Name:                      factories.RandomString(10),
 						ModelVendor:               models.ModelVendorOPENAI,
 						ModelType:                 models.ModelTypeGpt4,
-						ModelParameters:           modelParameters,
-						ProviderPromptMessages:    promptMessages,
+						ModelParameters:           *modelParameters,
+						ProviderPromptMessages:    *promptMessages,
 						ExpectedTemplateVariables: []string{""},
 						IsDefault:                 false,
 					})
@@ -1079,8 +1081,8 @@ func TestPromptConfigAPI(t *testing.T) { //nolint: revive
 					Name:                      "abc prompt config",
 					ModelVendor:               models.ModelVendorOPENAI,
 					ModelType:                 models.ModelTypeGpt4,
-					ModelParameters:           modelParameters,
-					ProviderPromptMessages:    promptMessages,
+					ModelParameters:           *modelParameters,
+					ProviderPromptMessages:    *promptMessages,
 					ExpectedTemplateVariables: []string{""},
 					IsDefault:                 true,
 				})
@@ -1115,8 +1117,8 @@ func TestPromptConfigAPI(t *testing.T) { //nolint: revive
 					Name:                      "abc prompt config",
 					ModelVendor:               models.ModelVendorOPENAI,
 					ModelType:                 models.ModelTypeGpt4,
-					ModelParameters:           modelParameters,
-					ProviderPromptMessages:    promptMessages,
+					ModelParameters:           *modelParameters,
+					ProviderPromptMessages:    *promptMessages,
 					ExpectedTemplateVariables: []string{""},
 					IsDefault:                 true,
 				})
@@ -1146,8 +1148,8 @@ func TestPromptConfigAPI(t *testing.T) { //nolint: revive
 					Name:                      factories.RandomString(10),
 					ModelVendor:               models.ModelVendorOPENAI,
 					ModelType:                 models.ModelTypeGpt4,
-					ModelParameters:           modelParameters,
-					ProviderPromptMessages:    promptMessages,
+					ModelParameters:           *modelParameters,
+					ProviderPromptMessages:    *promptMessages,
 					ExpectedTemplateVariables: []string{""},
 					IsDefault:                 true,
 				})
@@ -1156,21 +1158,21 @@ func TestPromptConfigAPI(t *testing.T) { //nolint: revive
 
 			promptConfigToRenameID := db.UUIDToString(&promptConfigToRename.ID)
 
-			newModelParameters := serialization.SerializeJSON(map[string]float32{
-				"temperature":       2,
-				"top_p":             2,
-				"max_tokens":        2,
-				"presence_penalty":  2,
-				"frequency_penalty": 2,
-			})
-
-			jsonMessage := newModelParameters
+			newModelParameters := ptr.To(
+				json.RawMessage(serialization.SerializeJSON(map[string]float32{
+					"temperature":       2,
+					"top_p":             2,
+					"max_tokens":        2,
+					"presence_penalty":  2,
+					"frequency_penalty": 2,
+				})),
+			)
 
 			response, requestErr := testClient.Patch(
 				context.TODO(),
 				fmtDetailEndpoint(projectID, applicationID, promptConfigToRenameID),
 				dto.PromptConfigUpdateDTO{
-					ModelParameters: &jsonMessage,
+					ModelParameters: newModelParameters,
 				})
 			assert.NoError(t, requestErr)
 			assert.Equal(t, http.StatusOK, response.StatusCode)
@@ -1178,7 +1180,7 @@ func TestPromptConfigAPI(t *testing.T) { //nolint: revive
 			dbPromptConfig, retrivalErr := db.GetQueries().
 				RetrievePromptConfig(context.TODO(), promptConfigToRename.ID)
 			assert.NoError(t, retrivalErr)
-			assert.Equal(t, newModelParameters, dbPromptConfig.ModelParameters)
+			assert.Equal(t, []byte(*newModelParameters), dbPromptConfig.ModelParameters)
 		})
 
 		t.Run("invalidates prompt-config cache", func(t *testing.T) {
@@ -1191,8 +1193,8 @@ func TestPromptConfigAPI(t *testing.T) { //nolint: revive
 					Name:                      factories.RandomString(10),
 					ModelVendor:               models.ModelVendorOPENAI,
 					ModelType:                 models.ModelTypeGpt4,
-					ModelParameters:           modelParameters,
-					ProviderPromptMessages:    promptMessages,
+					ModelParameters:           *modelParameters,
+					ProviderPromptMessages:    *promptMessages,
 					ExpectedTemplateVariables: []string{""},
 					IsDefault:                 true,
 				})
@@ -1282,8 +1284,8 @@ func TestPromptConfigAPI(t *testing.T) { //nolint: revive
 					Name:                      factories.RandomString(10),
 					ModelVendor:               models.ModelVendorOPENAI,
 					ModelType:                 models.ModelTypeGpt4,
-					ModelParameters:           modelParameters,
-					ProviderPromptMessages:    promptMessages,
+					ModelParameters:           *modelParameters,
+					ProviderPromptMessages:    *promptMessages,
 					ExpectedTemplateVariables: []string{""},
 					IsDefault:                 false,
 				})
@@ -1311,8 +1313,8 @@ func TestPromptConfigAPI(t *testing.T) { //nolint: revive
 					Name:                      factories.RandomString(10),
 					ModelVendor:               models.ModelVendorOPENAI,
 					ModelType:                 models.ModelTypeGpt4,
-					ModelParameters:           modelParameters,
-					ProviderPromptMessages:    promptMessages,
+					ModelParameters:           *modelParameters,
+					ProviderPromptMessages:    *promptMessages,
 					ExpectedTemplateVariables: []string{""},
 					IsDefault:                 false,
 				})
@@ -1346,8 +1348,8 @@ func TestPromptConfigAPI(t *testing.T) { //nolint: revive
 						Name:                      factories.RandomString(10),
 						ModelVendor:               models.ModelVendorOPENAI,
 						ModelType:                 models.ModelTypeGpt4,
-						ModelParameters:           modelParameters,
-						ProviderPromptMessages:    promptMessages,
+						ModelParameters:           *modelParameters,
+						ProviderPromptMessages:    *promptMessages,
 						ExpectedTemplateVariables: []string{""},
 						IsDefault:                 false,
 					})
@@ -1379,8 +1381,8 @@ func TestPromptConfigAPI(t *testing.T) { //nolint: revive
 						Name:                      factories.RandomString(10),
 						ModelVendor:               models.ModelVendorOPENAI,
 						ModelType:                 models.ModelTypeGpt4,
-						ModelParameters:           modelParameters,
-						ProviderPromptMessages:    promptMessages,
+						ModelParameters:           *modelParameters,
+						ProviderPromptMessages:    *promptMessages,
 						ExpectedTemplateVariables: []string{""},
 						IsDefault:                 false,
 					})
@@ -1415,8 +1417,8 @@ func TestPromptConfigAPI(t *testing.T) { //nolint: revive
 						Name:                      factories.RandomString(10),
 						ModelVendor:               models.ModelVendorOPENAI,
 						ModelType:                 models.ModelTypeGpt4,
-						ModelParameters:           modelParameters,
-						ProviderPromptMessages:    promptMessages,
+						ModelParameters:           *modelParameters,
+						ProviderPromptMessages:    *promptMessages,
 						ExpectedTemplateVariables: []string{""},
 						IsDefault:                 true,
 					})

--- a/services/dashboard-backend/internal/api/supportrequest_test.go
+++ b/services/dashboard-backend/internal/api/supportrequest_test.go
@@ -85,12 +85,12 @@ func TestSupportAPI(t *testing.T) {
 			//	emailSenderData.TemplateVariables["subject"],
 			//	supportRequestBody.EmailSubject,
 			//)
-			//assert.Equal(
+			// assert.Equal(
 			//	t,
 			//	emailSenderData.TemplateVariables["topic"],
 			//	supportRequestBody.RequestTopic,
 			//)
-			//assert.Equal(
+			// assert.Equal(
 			//	t,
 			//	emailSenderData.TemplateVariables["userId"],
 			//	db.UUIDToString(&userAccount.ID),

--- a/services/dashboard-backend/internal/api/ws_test.go
+++ b/services/dashboard-backend/internal/api/ws_test.go
@@ -145,8 +145,8 @@ func TestPromptTestingAPI(t *testing.T) {
 		Name:                   "test",
 		ModelVendor:            promptConfig.ModelVendor,
 		ModelType:              promptConfig.ModelType,
-		ModelParameters:        promptConfig.ModelParameters,
-		ProviderPromptMessages: promptConfig.ProviderPromptMessages,
+		ModelParameters:        ptr.To(json.RawMessage(promptConfig.ModelParameters)),
+		ProviderPromptMessages: ptr.To(json.RawMessage(promptConfig.ProviderPromptMessages)),
 		TemplateVariables:      templateVariables,
 		PromptConfigID:         &promptConfigID,
 	}
@@ -385,12 +385,14 @@ func TestPromptTestingAPI(t *testing.T) {
 			"should create the expected payload when PromptRequestRecordId is nil",
 			func(t *testing.T) {
 				data := &dto.PromptConfigTestDTO{
-					Name:                   "test",
-					ModelVendor:            models.ModelVendorOPENAI,
-					ModelType:              models.ModelTypeGpt4,
-					ProviderPromptMessages: promptConfig.ProviderPromptMessages,
-					ModelParameters:        promptConfig.ModelParameters,
-					TemplateVariables:      templateVariables,
+					Name:        "test",
+					ModelVendor: models.ModelVendorOPENAI,
+					ModelType:   models.ModelTypeGpt4,
+					ProviderPromptMessages: ptr.To(
+						json.RawMessage(promptConfig.ProviderPromptMessages),
+					),
+					ModelParameters:   ptr.To(json.RawMessage(promptConfig.ModelParameters)),
+					TemplateVariables: templateVariables,
 				}
 				msg := &ptesting.PromptTestingStreamingPromptResponse{
 					Content: "test",
@@ -418,12 +420,14 @@ func TestPromptTestingAPI(t *testing.T) {
 					promptConfig.ID,
 				)
 				data := &dto.PromptConfigTestDTO{
-					Name:                   "test",
-					ModelVendor:            models.ModelVendorOPENAI,
-					ModelType:              models.ModelTypeGpt4,
-					ProviderPromptMessages: promptConfig.ProviderPromptMessages,
-					ModelParameters:        promptConfig.ModelParameters,
-					TemplateVariables:      templateVariables,
+					Name:        "test",
+					ModelVendor: models.ModelVendorOPENAI,
+					ModelType:   models.ModelTypeGpt4,
+					ProviderPromptMessages: ptr.To(
+						json.RawMessage(promptConfig.ProviderPromptMessages),
+					),
+					ModelParameters:   ptr.To(json.RawMessage(promptConfig.ModelParameters)),
+					TemplateVariables: templateVariables,
 				}
 				msg := &ptesting.PromptTestingStreamingPromptResponse{
 					Content:               "test",
@@ -463,12 +467,14 @@ func TestPromptTestingAPI(t *testing.T) {
 		t.Run("should write error payload when receiving an error", func(t *testing.T) {
 			m := &mockSocket{}
 			data := &dto.PromptConfigTestDTO{
-				Name:                   "test",
-				ModelVendor:            models.ModelVendorOPENAI,
-				ModelType:              models.ModelTypeGpt4,
-				ProviderPromptMessages: promptConfig.ProviderPromptMessages,
-				ModelParameters:        promptConfig.ModelParameters,
-				TemplateVariables:      templateVariables,
+				Name:        "test",
+				ModelVendor: models.ModelVendorOPENAI,
+				ModelType:   models.ModelTypeGpt4,
+				ProviderPromptMessages: ptr.To(
+					json.RawMessage(promptConfig.ProviderPromptMessages),
+				),
+				ModelParameters:   ptr.To(json.RawMessage(promptConfig.ModelParameters)),
+				TemplateVariables: templateVariables,
 			}
 			errChannel := make(chan error)
 			responseChannel := make(chan *ptesting.PromptTestingStreamingPromptResponse)
@@ -510,12 +516,14 @@ func TestPromptTestingAPI(t *testing.T) {
 		t.Run("should return error on write error", func(t *testing.T) {
 			m := &mockSocket{}
 			data := &dto.PromptConfigTestDTO{
-				Name:                   "test",
-				ModelVendor:            models.ModelVendorOPENAI,
-				ModelType:              models.ModelTypeGpt4,
-				ProviderPromptMessages: promptConfig.ProviderPromptMessages,
-				ModelParameters:        promptConfig.ModelParameters,
-				TemplateVariables:      templateVariables,
+				Name:        "test",
+				ModelVendor: models.ModelVendorOPENAI,
+				ModelType:   models.ModelTypeGpt4,
+				ProviderPromptMessages: ptr.To(
+					json.RawMessage(promptConfig.ProviderPromptMessages),
+				),
+				ModelParameters:   ptr.To(json.RawMessage(promptConfig.ModelParameters)),
+				TemplateVariables: templateVariables,
 			}
 			errChannel := make(chan error)
 			responseChannel := make(chan *ptesting.PromptTestingStreamingPromptResponse)
@@ -556,12 +564,14 @@ func TestPromptTestingAPI(t *testing.T) {
 			outgoingErrChannel := make(chan error)
 
 			data := &dto.PromptConfigTestDTO{
-				Name:                   "test",
-				ModelVendor:            models.ModelVendorOPENAI,
-				ModelType:              models.ModelTypeGpt4,
-				ProviderPromptMessages: promptConfig.ProviderPromptMessages,
-				ModelParameters:        promptConfig.ModelParameters,
-				TemplateVariables:      templateVariables,
+				Name:        "test",
+				ModelVendor: models.ModelVendorOPENAI,
+				ModelType:   models.ModelTypeGpt4,
+				ProviderPromptMessages: ptr.To(
+					json.RawMessage(promptConfig.ProviderPromptMessages),
+				),
+				ModelParameters:   ptr.To(json.RawMessage(promptConfig.ModelParameters)),
+				TemplateVariables: templateVariables,
 			}
 			content := "is it tuesday?"
 			msg := &ptesting.PromptTestingStreamingPromptResponse{
@@ -607,12 +617,14 @@ func TestPromptTestingAPI(t *testing.T) {
 			outgoingErrChannel := make(chan error)
 
 			data := &dto.PromptConfigTestDTO{
-				Name:                   "test",
-				ModelVendor:            models.ModelVendorOPENAI,
-				ModelType:              models.ModelTypeGpt4,
-				ProviderPromptMessages: promptConfig.ProviderPromptMessages,
-				ModelParameters:        promptConfig.ModelParameters,
-				TemplateVariables:      templateVariables,
+				Name:        "test",
+				ModelVendor: models.ModelVendorOPENAI,
+				ModelType:   models.ModelTypeGpt4,
+				ProviderPromptMessages: ptr.To(
+					json.RawMessage(promptConfig.ProviderPromptMessages),
+				),
+				ModelParameters:   ptr.To(json.RawMessage(promptConfig.ModelParameters)),
+				TemplateVariables: templateVariables,
 			}
 
 			go func() {
@@ -642,12 +654,14 @@ func TestPromptTestingAPI(t *testing.T) {
 			outgoingErrChannel := make(chan error)
 
 			data := &dto.PromptConfigTestDTO{
-				Name:                   "test",
-				ModelVendor:            models.ModelVendorOPENAI,
-				ModelType:              models.ModelTypeGpt4,
-				ProviderPromptMessages: promptConfig.ProviderPromptMessages,
-				ModelParameters:        promptConfig.ModelParameters,
-				TemplateVariables:      templateVariables,
+				Name:        "test",
+				ModelVendor: models.ModelVendorOPENAI,
+				ModelType:   models.ModelTypeGpt4,
+				ProviderPromptMessages: ptr.To(
+					json.RawMessage(promptConfig.ProviderPromptMessages),
+				),
+				ModelParameters:   ptr.To(json.RawMessage(promptConfig.ModelParameters)),
+				TemplateVariables: templateVariables,
 			}
 
 			m.On("WriteMessage", gws.OpcodeText, mock.Anything).Return(assert.AnError)
@@ -681,12 +695,14 @@ func TestPromptTestingAPI(t *testing.T) {
 			outgoingErrChannel := make(chan error)
 
 			data := &dto.PromptConfigTestDTO{
-				Name:                   "test",
-				ModelVendor:            models.ModelVendorOPENAI,
-				ModelType:              models.ModelTypeGpt4,
-				ProviderPromptMessages: promptConfig.ProviderPromptMessages,
-				ModelParameters:        promptConfig.ModelParameters,
-				TemplateVariables:      templateVariables,
+				Name:        "test",
+				ModelVendor: models.ModelVendorOPENAI,
+				ModelType:   models.ModelTypeGpt4,
+				ProviderPromptMessages: ptr.To(
+					json.RawMessage(promptConfig.ProviderPromptMessages),
+				),
+				ModelParameters:   ptr.To(json.RawMessage(promptConfig.ModelParameters)),
+				TemplateVariables: templateVariables,
 			}
 
 			m.On("WriteMessage", gws.OpcodeText, mock.Anything).Return(nil)
@@ -735,34 +751,46 @@ func TestPromptTestingAPI(t *testing.T) {
 				{
 					Name: "should return error when name is empty",
 					Data: dto.PromptConfigTestDTO{
-						Name:                   "",
-						ModelVendor:            models.ModelVendorOPENAI,
-						ModelType:              models.ModelTypeGpt4,
-						ProviderPromptMessages: promptConfig.ProviderPromptMessages,
-						ModelParameters:        promptConfig.ModelParameters,
-						TemplateVariables:      templateVariables,
+						Name:        "",
+						ModelVendor: models.ModelVendorOPENAI,
+						ModelType:   models.ModelTypeGpt4,
+						ProviderPromptMessages: ptr.To(
+							json.RawMessage(promptConfig.ProviderPromptMessages),
+						),
+						ModelParameters: ptr.To(
+							json.RawMessage(promptConfig.ModelParameters),
+						),
+						TemplateVariables: templateVariables,
 					},
 				},
 				{
 					Name: "should return error when model vendor is invalid",
 					Data: dto.PromptConfigTestDTO{
-						Name:                   "test",
-						ModelVendor:            models.ModelVendor("invalid"),
-						ModelType:              models.ModelTypeGpt4,
-						ProviderPromptMessages: promptConfig.ProviderPromptMessages,
-						ModelParameters:        promptConfig.ModelParameters,
-						TemplateVariables:      templateVariables,
+						Name:        "test",
+						ModelVendor: models.ModelVendor("invalid"),
+						ModelType:   models.ModelTypeGpt4,
+						ProviderPromptMessages: ptr.To(
+							json.RawMessage(promptConfig.ProviderPromptMessages),
+						),
+						ModelParameters: ptr.To(
+							json.RawMessage(promptConfig.ModelParameters),
+						),
+						TemplateVariables: templateVariables,
 					},
 				},
 				{
 					Name: "should return error when model type is invalid",
 					Data: dto.PromptConfigTestDTO{
-						Name:                   "test",
-						ModelVendor:            models.ModelVendorOPENAI,
-						ModelType:              models.ModelType("invalid"),
-						ProviderPromptMessages: promptConfig.ProviderPromptMessages,
-						ModelParameters:        promptConfig.ModelParameters,
-						TemplateVariables:      templateVariables,
+						Name:        "test",
+						ModelVendor: models.ModelVendorOPENAI,
+						ModelType:   models.ModelType("invalid"),
+						ProviderPromptMessages: ptr.To(
+							json.RawMessage(promptConfig.ProviderPromptMessages),
+						),
+						ModelParameters: ptr.To(
+							json.RawMessage(promptConfig.ModelParameters),
+						),
+						TemplateVariables: templateVariables,
 					},
 				},
 				{
@@ -771,32 +799,40 @@ func TestPromptTestingAPI(t *testing.T) {
 						Name:                   "test",
 						ModelVendor:            models.ModelVendorOPENAI,
 						ModelType:              models.ModelTypeGpt432k,
-						ProviderPromptMessages: nil,
-						ModelParameters:        promptConfig.ModelParameters,
-						TemplateVariables:      templateVariables,
+						ProviderPromptMessages: ptr.To(json.RawMessage(nil)),
+						ModelParameters: ptr.To(
+							json.RawMessage(promptConfig.ModelParameters),
+						),
+						TemplateVariables: templateVariables,
 					},
 				},
 				{
 					Name: "should return error when model Parameters are empty",
 					Data: dto.PromptConfigTestDTO{
-						Name:                   "test",
-						ModelVendor:            models.ModelVendorOPENAI,
-						ModelType:              models.ModelTypeGpt432k,
-						ProviderPromptMessages: promptConfig.ProviderPromptMessages,
-						ModelParameters:        nil,
-						TemplateVariables:      templateVariables,
+						Name:        "test",
+						ModelVendor: models.ModelVendorOPENAI,
+						ModelType:   models.ModelTypeGpt432k,
+						ProviderPromptMessages: ptr.To(
+							json.RawMessage(promptConfig.ProviderPromptMessages),
+						),
+						ModelParameters:   nil,
+						TemplateVariables: templateVariables,
 					},
 				},
 				{
 					Name: "should return error when promptConfigID is not a uuid4",
 					Data: dto.PromptConfigTestDTO{
-						Name:                   "test",
-						ModelVendor:            models.ModelVendorOPENAI,
-						ModelType:              models.ModelTypeGpt432k,
-						ProviderPromptMessages: promptConfig.ProviderPromptMessages,
-						ModelParameters:        promptConfig.ModelParameters,
-						TemplateVariables:      templateVariables,
-						PromptConfigID:         &invalidID,
+						Name:        "test",
+						ModelVendor: models.ModelVendorOPENAI,
+						ModelType:   models.ModelTypeGpt432k,
+						ProviderPromptMessages: ptr.To(
+							json.RawMessage(promptConfig.ProviderPromptMessages),
+						),
+						ModelParameters: ptr.To(
+							json.RawMessage(promptConfig.ModelParameters),
+						),
+						TemplateVariables: templateVariables,
+						PromptConfigID:    &invalidID,
 					},
 				},
 			}
@@ -813,13 +849,15 @@ func TestPromptTestingAPI(t *testing.T) {
 
 		t.Run("should create a new prompt config when prompt config id is nil", func(t *testing.T) {
 			d := dto.PromptConfigTestDTO{
-				Name:                   factories.RandomString(10),
-				ModelVendor:            models.ModelVendorOPENAI,
-				ModelType:              models.ModelTypeGpt432k,
-				ProviderPromptMessages: promptConfig.ProviderPromptMessages,
-				ModelParameters:        promptConfig.ModelParameters,
-				TemplateVariables:      templateVariables,
-				PromptConfigID:         nil,
+				Name:        factories.RandomString(10),
+				ModelVendor: models.ModelVendorOPENAI,
+				ModelType:   models.ModelTypeGpt432k,
+				ProviderPromptMessages: ptr.To(
+					json.RawMessage(promptConfig.ProviderPromptMessages),
+				),
+				ModelParameters:   ptr.To(json.RawMessage(promptConfig.ModelParameters)),
+				TemplateVariables: templateVariables,
+				PromptConfigID:    nil,
 			}
 			serializedData := serialization.SerializeJSON(d)
 			message := &gws.Message{Data: bytes.NewBuffer(serializedData)}
@@ -833,8 +871,8 @@ func TestPromptTestingAPI(t *testing.T) {
 			assert.Equal(t, pc.Name, fmt.Sprintf("prompt config for test: %s", d.Name))
 			assert.Equal(t, pc.ModelVendor, d.ModelVendor)
 			assert.Equal(t, pc.ModelType, d.ModelType)
-			assert.Equal(t, pc.ModelParameters, d.ModelParameters)
-			assert.Equal(t, pc.ProviderPromptMessages, d.ProviderPromptMessages)
+			assert.Equal(t, pc.ModelParameters, []byte(*d.ModelParameters))
+			assert.Equal(t, pc.ProviderPromptMessages, []byte(*d.ProviderPromptMessages))
 			assert.Equal(t, pc.IsTestConfig, true)
 		})
 	})

--- a/services/dashboard-backend/internal/dto/dto.go
+++ b/services/dashboard-backend/internal/dto/dto.go
@@ -1,6 +1,7 @@
 package dto
 
 import (
+	"encoding/json"
 	"github.com/basemind-ai/monorepo/shared/go/db/models"
 	"github.com/shopspring/decimal"
 	"time"
@@ -29,20 +30,20 @@ type ProjectDTO struct { // skipcq: TCV-001
 // PromptConfigCreateDTO - DTO for prompt config CREATE request body.
 type PromptConfigCreateDTO struct { // skipcq: TCV-001
 	Name                   string             `json:"name"            validate:"required"`
-	ModelParameters        []byte             `json:"modelParameters" validate:"required"`
+	ModelParameters        *json.RawMessage   `json:"modelParameters" validate:"required"`
 	ModelType              models.ModelType   `json:"modelType"       validate:"oneof=gpt-3.5-turbo gpt-3.5-turbo-16k gpt-4 gpt-4-32k"`
 	ModelVendor            models.ModelVendor `json:"modelVendor"     validate:"oneof=OPEN_AI"`
-	ProviderPromptMessages []byte             `json:"promptMessages"  validate:"required"`
+	ProviderPromptMessages *json.RawMessage   `json:"promptMessages"  validate:"required"`
 	IsTest                 bool               `json:"isTest"`
 }
 
 // PromptConfigUpdateDTO - DTO for prompt config UPDATE request body.
 type PromptConfigUpdateDTO struct { // skipcq: TCV-001
 	Name                   *string             `json:"name,omitempty"            validate:"omitempty,required"`
-	ModelParameters        *[]byte             `json:"modelParameters,omitempty" validate:"omitempty,required"`
+	ModelParameters        *json.RawMessage    `json:"modelParameters,omitempty" validate:"omitempty,required"`
 	ModelType              *models.ModelType   `json:"modelType,omitempty"       validate:"omitempty,oneof=gpt-3.5-turbo gpt-3.5-turbo-16k gpt-4 gpt-4-32k"`
 	ModelVendor            *models.ModelVendor `json:"modelVendor,omitempty"     validate:"omitempty,oneof=OPEN_AI"`
-	ProviderPromptMessages *[]byte             `json:"promptMessages,omitempty"  validate:"omitempty,required"`
+	ProviderPromptMessages *json.RawMessage    `json:"promptMessages,omitempty"  validate:"omitempty,required"`
 }
 
 // ApplicationAPIKeyDTO - DTO for serializing application api key data.
@@ -86,10 +87,10 @@ type AnalyticsDTO struct { // skipcq: TCV-001
 // PromptConfigTestDTO - DTO for requesting a prompt config test.
 type PromptConfigTestDTO struct { // skipcq: TCV-001
 	Name                   string             `json:"name"                        validate:"required"`
-	ModelParameters        []byte             `json:"modelParameters,omitempty"   validate:"omitempty,required"`
+	ModelParameters        *json.RawMessage   `json:"modelParameters,omitempty"   validate:"omitempty,required"`
 	ModelType              models.ModelType   `json:"modelType"                   validate:"oneof=gpt-3.5-turbo gpt-3.5-turbo-16k gpt-4 gpt-4-32k"`
 	ModelVendor            models.ModelVendor `json:"modelVendor"                 validate:"oneof=OPEN_AI"`
-	ProviderPromptMessages []byte             `json:"promptMessages,omitempty"    validate:"omitempty,required"`
+	ProviderPromptMessages *json.RawMessage   `json:"promptMessages,omitempty"    validate:"omitempty,required"`
 	TemplateVariables      map[string]string  `json:"templateVariables,omitempty"`
 	PromptConfigID         *string            `json:"promptConfigId,omitempty"    validate:"omitempty,required,uuid4"`
 }

--- a/services/dashboard-backend/internal/ptestingclient/ptestingclient.go
+++ b/services/dashboard-backend/internal/ptestingclient/ptestingclient.go
@@ -86,8 +86,8 @@ func (c *Client) StreamPromptTest(
 			PromptConfigId:         *data.PromptConfigID,
 			ModelVendor:            string(data.ModelVendor),
 			ModelType:              string(data.ModelType),
-			ModelParameters:        data.ModelParameters,
-			ProviderPromptMessages: data.ProviderPromptMessages,
+			ModelParameters:        *data.ModelParameters,
+			ProviderPromptMessages: *data.ProviderPromptMessages,
 			TemplateVariables:      data.TemplateVariables,
 		},
 	)

--- a/services/dashboard-backend/internal/ptestingclient/ptestingclient_test.go
+++ b/services/dashboard-backend/internal/ptestingclient/ptestingclient_test.go
@@ -2,6 +2,7 @@ package ptestingclient_test
 
 import (
 	"context"
+	"encoding/json"
 	"github.com/basemind-ai/monorepo/e2e/factories"
 	"github.com/basemind-ai/monorepo/gen/go/ptesting/v1"
 	"github.com/basemind-ai/monorepo/services/dashboard-backend/internal/dto"
@@ -13,6 +14,7 @@ import (
 	"github.com/stretchr/testify/mock"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
+	"k8s.io/utils/ptr"
 	"net"
 	"testing"
 )
@@ -78,10 +80,10 @@ func TestPromptTestingGRPCClient(t *testing.T) {
 	promptRequestRecordID := db.UUIDToString(&promptRequestRecord.ID)
 	data := dto.PromptConfigTestDTO{
 		Name:                   "TEST",
-		ModelParameters:        promptConfig.ModelParameters,
+		ModelParameters:        ptr.To(json.RawMessage(promptConfig.ModelParameters)),
 		ModelType:              models.ModelTypeGpt432k,
 		ModelVendor:            models.ModelVendorOPENAI,
-		ProviderPromptMessages: promptConfig.ProviderPromptMessages,
+		ProviderPromptMessages: ptr.To(json.RawMessage(promptConfig.ProviderPromptMessages)),
 		TemplateVariables:      map[string]string{},
 		PromptConfigID:         &promptConfigID,
 	}

--- a/services/dashboard-backend/internal/repositories/utils_test.go
+++ b/services/dashboard-backend/internal/repositories/utils_test.go
@@ -1,18 +1,20 @@
 package repositories_test
 
 import (
+	"encoding/json"
 	"github.com/basemind-ai/monorepo/services/dashboard-backend/internal/repositories"
 	"github.com/basemind-ai/monorepo/shared/go/db/models"
 	"github.com/stretchr/testify/assert"
+	"k8s.io/utils/ptr"
 	"testing"
 )
 
 func TestUtils(t *testing.T) {
 	t.Run("ParsePromptMessages", func(t *testing.T) {
 		t.Run("parses openai messages", func(t *testing.T) {
-			promptMessages := []byte(
+			promptMessages := ptr.To(json.RawMessage(
 				`[{"role": "user", "content": "Hello {name}!"}, {"role": "system", "content": "You are a helpful chatbot."}]`,
-			)
+			))
 			vendor := models.ModelVendorOPENAI
 
 			expectedVariables, parsedMessages, err := repositories.ParsePromptMessages(
@@ -26,9 +28,9 @@ func TestUtils(t *testing.T) {
 		})
 
 		t.Run("de-duplicates template variables", func(t *testing.T) {
-			promptMessages := []byte(
+			promptMessages := ptr.To(json.RawMessage(
 				`[{"role": "user", "content": "Hello {name}!"}, {"role": "system", "content": "You are a helpful {name}."}]`,
-			)
+			))
 			vendor := models.ModelVendorOPENAI
 
 			expectedVariables, parsedMessages, err := repositories.ParsePromptMessages(
@@ -42,25 +44,25 @@ func TestUtils(t *testing.T) {
 		})
 
 		t.Run("returns error for invalid JSON prompt message", func(t *testing.T) {
-			promptMessages := []byte(`invalid`)
+			promptMessages := ptr.To(json.RawMessage(`invalid`))
 
 			_, _, err := repositories.ParsePromptMessages(promptMessages, models.ModelVendorOPENAI)
 			assert.Error(t, err)
 		})
 
 		t.Run("returns error for invalid vendor", func(t *testing.T) {
-			promptMessages := []byte(
+			promptMessages := ptr.To(json.RawMessage(
 				`[{"role": "user", "content": "Hello {name}!"}, {"role": "system", "content": "You are a helpful {name}."}]`,
-			)
+			))
 			vendor := models.ModelVendor("abc")
 			_, _, err := repositories.ParsePromptMessages(promptMessages, vendor)
 			assert.Error(t, err)
 		})
 
 		t.Run("returns error for invalid role", func(t *testing.T) {
-			promptMessages := []byte(
+			promptMessages := ptr.To(json.RawMessage(
 				`[{"role": "x", "content": "Hello {name}!"}, {"role": "system", "content": "You are a helpful {name}."}]`,
-			)
+			))
 			vendor := models.ModelVendorOPENAI
 			_, _, err := repositories.ParsePromptMessages(promptMessages, vendor)
 			assert.Error(t, err)

--- a/services/openai-connector/package.json
+++ b/services/openai-connector/package.json
@@ -14,7 +14,7 @@
 		"@protobuf-ts/runtime": "^2.9.1",
 		"@protobuf-ts/runtime-rpc": "^2.9.1",
 		"grpc-health-check": "^2.0.0",
-		"openai": "^4.17.3",
+		"openai": "^4.17.4",
 		"pino": "^8.16.1"
 	}
 }

--- a/shared/go/datatypes/datatypes.go
+++ b/shared/go/datatypes/datatypes.go
@@ -1,6 +1,7 @@
 package datatypes
 
 import (
+	"encoding/json"
 	"github.com/basemind-ai/monorepo/shared/go/db/models"
 	"github.com/shopspring/decimal"
 	"time"
@@ -30,10 +31,10 @@ type OpenAIModelParametersDTO struct { // skipcq: TCV-001
 type PromptConfigDTO struct { // skipcq: TCV-001
 	ID                        string             `json:"id"`
 	Name                      string             `json:"name"                      validate:"required"`
-	ModelParameters           []byte             `json:"modelParameters"           validate:"required"`
+	ModelParameters           *json.RawMessage   `json:"modelParameters"           validate:"required"`
 	ModelType                 models.ModelType   `json:"modelType"                 validate:"oneof=gpt-3.5-turbo gpt-3.5-turbo-16k gpt-4 gpt-4-32k"`
 	ModelVendor               models.ModelVendor `json:"modelVendor"               validate:"oneof=OPEN_AI"`
-	ProviderPromptMessages    []byte             `json:"providerPromptMessages"    validate:"required"`
+	ProviderPromptMessages    *json.RawMessage   `json:"providerPromptMessages"    validate:"required"`
 	ExpectedTemplateVariables []string           `json:"expectedTemplateVariables"`
 	IsDefault                 bool               `json:"isDefault,omitempty"`
 	CreatedAt                 time.Time          `json:"createdAt,omitempty"`


### PR DESCRIPTION
This PR updates our DTOs to use a `json.RawMessage` pointer instead of `[]byte` - in an attempt to resolve the issue where raw json is encoded as base64 string when sent to the frontend. 